### PR TITLE
Bump version of mongo driver to 4.3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"
     compileOnly "org.embulk:embulk-spi:0.10.31"
-    compile "org.mongodb:mongo-java-driver:3.8.1"
+    compile "org.mongodb:mongo-java-driver:4.3.4"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"
     compileOnly "org.embulk:embulk-spi:0.10.31"
-    compile "org.mongodb:mongodb-driver-sync:4.3.4"
+    compile "org.mongodb:mongo-java-driver:3.12.9"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"
     compileOnly "org.embulk:embulk-spi:0.10.31"
-    compile "org.mongodb:mongo-java-driver:4.3.4"
+    compile "org.mongodb:mongodb-driver-sync:4.3.4"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,4 +7,4 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.1
-org.mongodb:mongo-java-driver:3.8.1
+org.mongodb:mongo-java-driver:4.3.4

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,4 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.1
-org.mongodb:mongo-java-driver:4.3.4
+org.mongodb:bson:4.3.4
+org.mongodb:mongodb-driver-core:4.3.4
+org.mongodb:mongodb-driver-sync:4.3.4

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,4 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.1
-org.mongodb:bson:4.3.4
-org.mongodb:mongodb-driver-core:4.3.4
-org.mongodb:mongodb-driver-sync:4.3.4
+org.mongodb:mongo-java-driver:3.12.9


### PR DESCRIPTION
mongo driver 4.3.4 supports mongo 5.0

https://www.mongodb.com/docs/drivers/java/sync/current/compatibility/